### PR TITLE
Improve event recording for play/pause and rebuffering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint"
-  ],
+  "plugins": ["@typescript-eslint"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # metrics
 
-[![npm version](https://img.shields.io/npm/v/%40maveio%2Fmetrics?color=5850ec)](https://www.npmjs.com/package/@maveio/metrics) 
+[![npm version](https://img.shields.io/npm/v/%40maveio%2Fmetrics?color=5850ec)](https://www.npmjs.com/package/@maveio/metrics)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/maveio/metrics/github-code-scanning%2Fcodeql?label=CodeQL&color=5850ec)](https://github.com/maveio/metrics/actions/workflows/github-code-scanning/codeql)
 [![Discord server](https://img.shields.io/badge/Discord-mave.io-5850ec)](https://discord.gg/SBCKwnwHkC)
 
@@ -33,24 +33,24 @@ npm install @maveio/metrics
 ```javascript
 import { Metrics } from '@maveio/metrics';
 Metrics.config = {
-    socketPath: 'wss://{your domain here}/socket',
-    apiKey: '{your api key here}',
-}
+  socketPath: 'wss://{your domain here}/socket',
+  apiKey: '{your api key here}',
+};
 ```
-  
+
 To collect video events you will need to create an Metrics instance using each `HTMLVideoElement` or `Hls` object:
 
-`new Metrics(<querySelector | Hls object>, <string>, <optional video query metadata>, <optional session query metadata>)` 
+`new Metrics(<querySelector | Hls object>, <string>, <optional video query metadata>, <optional session query metadata>)`
 
 For instance, you can do this in your page:
-  
+
 ```javascript
-const metrics = new Metrics("#my_video", "label name", {
+const metrics = new Metrics('#my_video', 'label name', {
   my_custom_query_id: 1234,
-})
-metrics.monitor()
+});
+metrics.monitor();
 ```
-  
+
 When you are using the hls.js library you can use the following code to monitor the video:
 
 ```javascript
@@ -61,9 +61,9 @@ if (Hls.isSupported()) {
   const hls = new Hls();
   hls.loadSource(videoSrc);
   hls.attachMedia(video);
-  new Metrics(hls, "Big buck bunny").monitor()
+  new Metrics(hls, 'Big buck bunny').monitor();
 } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
   video.src = videoSrc;
-  new Metrics("#hls_video", "Big buck bunny").monitor()
+  new Metrics('#hls_video', 'Big buck bunny').monitor();
 }
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,3 @@
 # Security Policy
 
 Please read our [responsible disclosure](https://mave.io/docs/responsible-disclosure/)
-

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "./node_modules/.bin/tsup --dts --minify",
-    "build:watch": "./node_modules/.bin/tsup src/index.ts --watch --dts --minify",
+    "dev": "./node_modules/.bin/tsup src/index.ts --watch --dts --minify",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix"
+    "lint:fix": "eslint . --ext .ts --fix",
+    "prettier": "npx prettier . --write"
   },
   "files": [
     "dist"

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,5 +1,5 @@
-import { Channel, Socket } from "phoenix";
-import { uuid } from "./utils";
+import { Channel, Socket } from 'phoenix';
+import { uuid } from './utils';
 
 export interface ChannelTopic extends Channel {
   topic: string;
@@ -15,10 +15,10 @@ export default class Data {
   private static instance: Data;
 
   private constructor() {
-    return
+    return;
   }
 
-  public static set config(config: { apiKey: string, socketPath: string }) {
+  public static set config(config: { apiKey: string; socketPath: string }) {
     if (!Data.instance) {
       Data.instance = new Data();
     }
@@ -31,39 +31,53 @@ export default class Data {
       Data.instance = new Data();
     }
 
-    if(!Data.instance.#key && !Data.instance.#warningKeyGiven) {
-      console.warn("[metrics]: Set apiKey using `Metrics.config = {apiKey: 'your_key'}`")
+    if (!Data.instance.#key && !Data.instance.#warningKeyGiven) {
+      console.warn(
+        "[metrics]: Set apiKey using `Metrics.config = {apiKey: 'your_key'}`"
+      );
       Data.instance.#warningKeyGiven = true;
     }
 
-    if(!Data.instance.#path && !Data.instance.#warningPathGiven) {
-      console.warn("[metrics]: Set path using `Metrics.config = {socketPath: 'ws://localhost:3000/socket`}")
+    if (!Data.instance.#path && !Data.instance.#warningPathGiven) {
+      console.warn(
+        "[metrics]: Set path using `Metrics.config = {socketPath: 'ws://localhost:3000/socket`}"
+      );
       Data.instance.#warningPathGiven = true;
     }
 
-    if(!Data.instance.#socket) {
-      if(window) {
-        Data.instance.#socket = new Socket(Data.instance.#path || 'ws://localhost:3000/socket', {
-          params: {
-            source_url: window.location.href,
-            key: Data.instance.#key
+    if (!Data.instance.#socket) {
+      if (window) {
+        Data.instance.#socket = new Socket(
+          Data.instance.#path || 'ws://localhost:3000/socket',
+          {
+            params: {
+              source_url: window.location.href,
+              key: Data.instance.#key,
+            },
           }
-        })
+        );
         Data.instance.#socket.connect();
       }
-    }    
+    }
 
     return Data.instance.#socket;
   }
 
-  public static startSession(video: HTMLVideoElement, metadata?: object): Channel {
+  public static startSession(
+    video: HTMLVideoElement,
+    metadata?: object
+  ): Channel {
     const result = Data.instance.#channels.get(video);
 
     if (result) {
       return result;
     }
 
-    const session = Data.instance.#socket.channel(`session:${uuid()}`, {...metadata, source_url: window.location.href, key: Data.instance.#key});
+    const session = Data.instance.#socket.channel(`session:${uuid()}`, {
+      ...metadata,
+      source_url: window.location.href,
+      key: Data.instance.#key,
+    });
 
     Data.instance.#channels.set(video, session);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,17 +3,17 @@ export function uuid() {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return crypto
-  .getRandomValues(new Uint8Array(21))
-  .reduce(
-    (t, e) =>
-      (t +=
-        (e &= 63) < 36
-          ? e.toString(36)
-          : e < 62
-          ? (e - 26).toString(36).toUpperCase()
-          : e < 63
-          ? "_"
-          : "-"),
-    ""
-  );
+    .getRandomValues(new Uint8Array(21))
+    .reduce(
+      (t, e) =>
+        (t +=
+          (e &= 63) < 36
+            ? e.toString(36)
+            : e < 62
+            ? (e - 26).toString(36).toUpperCase()
+            : e < 63
+            ? '_'
+            : '-'),
+      ''
+    );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ESNext",
-    "lib": [
-      "esnext",
-      "dom",
-      "DOM.Iterable"
-    ],
+    "lib": ["esnext", "dom", "DOM.Iterable"],
     "strict": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
@@ -17,10 +13,7 @@
     "emitDeclarationOnly": true,
     "strictPropertyInitialization": false,
     "experimentalDecorators": true,
-    "useDefineForClassFields": false,
+    "useDefineForClassFields": false
   },
-  "include": [
-    "src/**/*",
-    "lib/index.d.ts"
-  ]
+  "include": ["src/**/*", "lib/index.d.ts"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   noExternal: ['phoenix'],
   esbuildPlugins: [
     replace({
-      '__buildVersion': json.version
+      __buildVersion: json.version,
     }),
-  ]
-})
+  ],
+});


### PR DESCRIPTION
- Fixes #4
- Update files according to lint
- Rebuffering is now recorded as duration instead of just an event
- Filter out other non-essential events
- Fix bug where seeked caused an incorrect `from` and `to` by simply sending another `pause`, `play` event.
- Server PR: https://github.com/maveio/metrics-server/pull/3